### PR TITLE
add merge function to replicate 2.0 experience

### DIFF
--- a/apollo.test.js
+++ b/apollo.test.js
@@ -58,7 +58,19 @@ describe.each([
       link: new HttpLink({
         uri: '/graphql',
       }),
-      cache: new Cache(),
+      cache: new Cache({
+        typePolicies: {
+          Query: {
+            fields: {
+              foo: {
+                merge(a, b) {
+                  return { ...a, ...b };
+                }
+              }
+            }
+          }
+        } 
+      }),
     });
 
     const barResult = await client.query({ query: BarQuery, } );


### PR DESCRIPTION
In 2.0, Apollo Client would (dangerously!) merge fields without identity. In this example, the query lacks any form of identifiable id/key so the second query overwrites the initial payload. The 2.0 experience created a huge set of unexpected experiences and bugs in production code that teams had no way to manage effectively. 3.0 allows for much better control over this (including that `typePolicies` can be lazily added per route) and replicating the previous "merge whatever you get" is possible with a simple spread. The `merge` function is only called when data is written to the cache (not when read) btw.

[These docs are being finished this week](https://www.apollographql.com/docs/react/v3.0-beta/caching/cache-configuration/#data-normalization) but may be hepful as early as Monday as you review this